### PR TITLE
18 manage clients using client id on server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/joho/godotenv v1.5.1
 )
+
+require github.com/google/uuid v1.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ go 1.20
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/joho/godotenv v1.5.1
 )
-
-require github.com/google/uuid v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/server/hub/client.go
+++ b/server/hub/client.go
@@ -49,8 +49,7 @@ func generateClientId(hub *Hub) string {
 		if err != nil {
 			log.Fatalf("Fail to generate uuid: %v", err)
 		}
-		_, exists := hub.clients[id]
-		if !exists {
+		if _, exists := hub.clients[id]; !exists {
 			return id
 		}
 	}

--- a/server/hub/client.go
+++ b/server/hub/client.go
@@ -45,10 +45,10 @@ func ServeWebsocket(hub *Hub, w http.ResponseWriter, r *http.Request) {
 func generateClientId(hub *Hub) string {
 	for {
 		randomUuid, err := uuid.NewRandom()
-		id := randomUuid.String()
 		if err != nil {
 			log.Fatalf("Fail to generate uuid: %v", err)
 		}
+		id := randomUuid.String()
 		if _, exists := hub.clients[id]; !exists {
 			return id
 		}

--- a/server/hub/client.go
+++ b/server/hub/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/CAEL0/tic-tac-toe/server/board"
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 )
 
@@ -37,6 +38,20 @@ func ServeWebsocket(hub *Hub, w http.ResponseWriter, r *http.Request) {
 
 	go client.readPump()
 	go client.writePump()
+}
+
+func generateClientId(hub *Hub) string {
+	for {
+		randomUuid, err := uuid.NewRandom()
+		id := randomUuid.String()
+		if err != nil {
+			log.Fatalf("Fail to generate uuid: %v", err)
+		}
+		_, exists := hub.clients[id]
+		if !exists {
+			return id
+		}
+	}
 }
 
 func (c *Client) readPump() {

--- a/server/hub/client.go
+++ b/server/hub/client.go
@@ -16,6 +16,7 @@ type Client struct {
 	conn  *websocket.Conn
 	send  chan []byte
 	board *board.Board
+	id    string
 }
 
 var upgrader = websocket.Upgrader{
@@ -33,6 +34,7 @@ func ServeWebsocket(hub *Hub, w http.ResponseWriter, r *http.Request) {
 		conn:  conn,
 		send:  make(chan []byte, 256),
 		board: board.New(),
+		id:    generateClientId(hub),
 	}
 	hub.register <- client
 


### PR DESCRIPTION
close #18 

Add a field `id` to the `Client` struct.
The `id` is generated by `uuid` package.
The `hub` manages clients by the map (key: `client id`, value: `client`).